### PR TITLE
fix hal shortcut

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -262,7 +262,7 @@ sudo tee /usr/local/bin/hal <<-'EOF'
 POD_NAME=$(kubectl -n spinnaker get pod -l app=halyard -oname | cut -d'/' -f 2)
 # echo $POD_NAME
 set -x
-kubectl -n spinnaker exec -i ${POD_NAME} -- hal $@
+kubectl -n spinnaker exec -i ${POD_NAME} -- sh -c "hal $@"
 EOF
 
 sudo chmod 755 /usr/local/bin/hal


### PR DESCRIPTION
The `hal` shortcut created by the `create_hal_shortcut` function did not work as expected : 
```
hal --version
error: Internal error occurred: error executing command in container: failed to exec in container: failed to start exec "1442c33c151c99cedde0c4198dd13519659b9169bbd971c557d075310aaf9602": OCI runtime exec failed: exec failed: container_linux.go:346: starting container process caused "exec format error": unknown
```

As shown later in the `install.sh` script, it is better to pass the command with `--sh -c` to avoid errors.