### PR TITLE
feat(k3s): Change k3s installation to allow remote kubectl calls

### DIFF
--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -18,7 +18,7 @@
 ARMORY_HALYARD_IMAGE="armory/halyard-armory:1.9.4"
 
 install_k3s () {
-  curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION="v1.17.7+k3s1" K3S_KUBECONFIG_MODE=644 sh -
+  curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="--tls-san $(cat ${BASE_DIR}/.hal/public_endpoint)" INSTALL_K3S_VERSION="v1.17.4+k3s1" K3S_KUBECONFIG_MODE=644 sh -
 }
 
 install_yq () {

--- a/scripts/operator_install.sh
+++ b/scripts/operator_install.sh
@@ -46,7 +46,7 @@ print_help () {
 
 install_k3s () {
   # curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="--no-deploy=traefik" K3S_KUBECONFIG_MODE=644 sh -
-  curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION="v1.17.4+k3s1" K3S_KUBECONFIG_MODE=644 sh -
+  curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="--tls-san $(cat ${BASE_DIR}/.hal/public_endpoint)" INSTALL_K3S_VERSION="v1.17.4+k3s1" K3S_KUBECONFIG_MODE=644 sh -
 }
 
 install_yq () {
@@ -223,10 +223,10 @@ if [[ ${LINUX} -eq 1 ]]; then
 
   sudo chown -R 1000 ${BASE_DIR}
 
+  detect_endpoint
+
   install_k3s
   install_yq
-
-  detect_endpoint
 
   sudo env "PATH=$PATH" kubectl config set-context default --namespace spinnaker
 

--- a/scripts/utils/external_service_setup.sh
+++ b/scripts/utils/external_service_setup.sh
@@ -43,7 +43,7 @@ done
 
 for svc in $(cat ${BASE_DIR}/.hal/all_services); do
   echo "Adding Minnaker reference to ${svc} to dev config..."
-  PORT=$(kubectl get svc spin-${svc} -ojsonpath='{.spec.ports[0].port}')
+  PORT=$(kubectl --context ${KUBERNETES_CONTEXT} -n ${NAMESPACE} get svc spin-${svc} -ojsonpath='{.spec.ports[0].port}')
   yq w -i ${BASE_DIR}/.hal/spinnaker-local.yml services.${svc}.baseUrl http://${MINNAKER_IP}:${PORT}
   echo "Configuring svc/spin-${svc} to type LoadBalancer"
   touch ${BASE_DIR}/.hal/default/service-settings/${SVC}.yml
@@ -53,7 +53,7 @@ done
 echo "Configuring Minnaker for these services:"
 for svc in $(cat ${BASE_DIR}/.hal/external_services); do
   echo "Adding external reference to ${svc} to Minnaker config..."
-  PORT=$(kubectl get svc spin-${svc} -ojsonpath='{.spec.ports[0].port}')
+  PORT=$(kubectl --context ${KUBERNETES_CONTEXT} -n ${NAMESPACE} get svc spin-${svc} -ojsonpath='{.spec.ports[0].port}')
   yq w -i ${BASE_DIR}/.hal/default/profiles/spinnaker-local.yml services.${svc}.baseUrl http://${EXTERNAL_IP}:${PORT}
   echo "Scaling Minnaker ${svc} to 0 instances..."
   yq w -i ${BASE_DIR}/.hal/config deploymentConfigurations[0].deploymentEnvironment.customSizing.spin-${svc}.replicas 0


### PR DESCRIPTION
This change will allow the user to make remote kubectl calls to the minnaker instance as long as minnaker is available on a public IP address. This will also allow the user to use Telepresence for plugin development

* Fix kubectl calls in script to make them consistent
* Change function order for operator installation
* Change K3s installation options to allow for remote kubectl calls