### PR TITLE
feat(minnaker): Patch release on GitHub action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,6 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: rymndhng/release-on-push-action@master
+      - uses: rymndhng/release-on-push-action@v0.16.0
         with:
           bump_version_scheme: patch


### PR DESCRIPTION
This PR will create a new patch-level release of Minnaker on subsequent pushes to `master`, using the [GitHub Release On Push Action](https://github.com/rymndhng/release-on-push-action).

This PR will not itself create a new release, because of the `norelease` label. We can create additional labels to further customize the behavior of the action, per the action's [README](https://github.com/rymndhng/release-on-push-action#how-do-i-change-the-bump-version-scheme-using-pull-requests)

**Note:** Due to a hard-coded naming convention in the Action (discussed [here](https://github.com/rymndhng/release-on-push-action/issues/42)), this will change the naming convention to include a "v" in the tag on future releases. Manual release procedures should be updated to conform to this convention, if acceptable.

EDIT: Since there are already updates in `master` that aren't in the latest release, consider removing the `norelease` label from this PR to update our current release.