### PR TITLE
installation needs `jq` as well

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -28,7 +28,7 @@ To use Minnaker, make sure your Linux instance meets the following requirements:
     * 30GiB of HDD (recommend 40+)
     * NAT or Bridged networking with access to the internet
     * Install `curl`, `git`, and `tar` (if they're not already installed):
-        * `sudo apt-get install curl git tar`
+        * `sudo apt-get install curl git tar jq`
     * Port `443` on your VM needs to be accessible from your workstation / browser. By default, Minnaker installs Spinnaker and configures it to listen on port `443`, using paths `/` and `/api/v1`(for the UI and API).
 * OSX
     * Docker Desktop local Kubernetes cluster enabled


### PR DESCRIPTION
```bash
[ERROR] 'jq' is not installed.[KUBE ] kubectl apply -f https://engineering.armory.io/manifests/pacrd-1.0.1.yaml -n spinnaker
[ERROR] Error executing command:
```